### PR TITLE
Fix slideshow wait loop

### DIFF
--- a/apps/showimage/showimage.cpp
+++ b/apps/showimage/showimage.cpp
@@ -579,7 +579,8 @@ int main([[maybe_unused]] int argc, const char **argv)
             memcpy(Video8BitFramebuffer, Video8BitFramebufferBack, VIDEO_8_BIT_MODE_ROWBYTES * VIDEO_8_BIT_MODE_HEIGHT);
             memcpy(Video8BitColorsToNTSC, Video8BitColorsToNTSCBack, sizeof(Video8BitColorsToNTSCBack));
 
-            for(int i = 0; i < 50 && !quit; i++)
+            uint32_t slideStart = RoGetMillis();
+            while(!quit && RoGetMillis() - slideStart < 5000)
             {
                 uint32_t nowTick = RoGetMillis();
                 if(nowTick >= prevTick + 10) {
@@ -608,7 +609,6 @@ int main([[maybe_unused]] int argc, const char **argv)
                             break;
                     }
                 }
-                RoDelayMillis(100);
             }
 
             std::shuffle(slideOrder.begin(), slideOrder.end(), rng);


### PR DESCRIPTION
## Summary
- update showimage slideshow loop to run until five seconds elapse
- remove unnecessary delay

## Testing
- `cmake -Bbuild .` *(fails: couldn't find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68871a9f62c88321ae029772a1a1aa2c